### PR TITLE
[python] fix: sentence length alignment

### DIFF
--- a/test.py
+++ b/test.py
@@ -31,7 +31,7 @@ def evaluate(model, test_loader):
         tgt_y = tgt_y.to(device)
 
         encoder_outputs, hidden, x = encoder(src_X)
-        encoder_mask = (src_X == 0).unsqueeze(1).byte()
+        encoder_mask = (src_X == 0)[:, : encoder_outputs.size(0)].unsqueeze(1)
         K = Kencoder(src_K)
         k_i = manager(x, None, K)
         n_batch = src_X.size(0)
@@ -42,7 +42,7 @@ def evaluate(model, test_loader):
         hidden = hidden[params.n_layer :]
         output = torch.LongTensor([params.SOS] * n_batch).to(device)  # [n_batch]
         for t in range(max_len):
-            output, hidden, attn_weights = decoder(
+            output, hidden = decoder(
                 output, k_i, hidden, encoder_outputs, encoder_mask
             )
             outputs[t] = output


### PR DESCRIPTION
- sentence length alignment
- change the number of decoder outputs

Refs: #8